### PR TITLE
Historical TVL Feature to Pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,26 @@ const userPoolBalance = await sdk.vaults.balanceOf(vault, pool, await signer.get
 const poolsTvl = await sdk.pools.getPoolsTvl(vault, [pool]);
 ```
 
+## Get historical TVL data for a vault and pool
+
+```ts
+// Fetch historical TVL data with various filter options
+const historicalTVL = await sdk.pools.historicalTVL({
+  vaultAddress: "0x1234...5678", // Required: The vault address to get TVL for
+  poolId: 1,                     // Required: The specific pool ID to query
+  fromTimestamp: 1641034800,     // Optional: Start time in seconds (Jan 1, 2022)
+  toTimestamp: 1672570800,       // Optional: End time in seconds (Jan 1, 2023)
+  page: 1,                       // Optional: Page number for pagination (starts at 1)
+  pageSize: 30                   // Optional: Number of records per page (max 100)
+});
+
+// Example with just the required parameters
+const currentTVL = await sdk.pools.historicalTVL({
+  vaultAddress: "0x1234...5678", 
+  poolId: 1
+});
+```
+
 ## Get yield data on vaults (filtering on vaults/timeframe)
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"description": "Yelay Lite SDK",
 	"main": "build/index.js",
 	"types": "build/index.d.ts",

--- a/src/adapters/backend/PoolsBackend.ts
+++ b/src/adapters/backend/PoolsBackend.ts
@@ -1,0 +1,43 @@
+import { IPoolsBackend } from '../../app/ports/backend/IPoolsBackend';
+import ApiWrapperService from '../../services/ApiWrapperService';
+import { HistoricalTVL, HistoricalTVLParams } from '../../types/pools';
+
+export class PoolsBackend extends ApiWrapperService implements IPoolsBackend {
+	private chainId: number;
+
+	constructor(backendUrl: string, chainId: number) {
+		super(backendUrl);
+		this.chainId = chainId;
+	}
+
+	/**
+	 * Retrieves historical TVL (Total Value Locked) data for a specific vault address and optional pool IDs.
+	 *
+	 * @param params - Object containing parameters for the historical TVL query
+	 * @returns A promise that resolves to an array of historical TVL data objects.
+	 */
+	async historicalTVL(params: HistoricalTVLParams): Promise<HistoricalTVL[]> {
+		const searchParams = new URLSearchParams();
+
+		searchParams.append('chainId', this.chainId.toString());
+		searchParams.append('vaultAddress', params.vaultAddress.toLowerCase());
+		searchParams.append('poolId', params.poolId.toString());
+
+		if (params.fromTimestamp) {
+			searchParams.append('fromTimestamp', params.fromTimestamp.toString());
+		}
+		if (params.toTimestamp) {
+			searchParams.append('toTimestamp', params.toTimestamp.toString());
+		}
+
+		if (params.page) {
+			searchParams.append('page', params.page.toString());
+		}
+		if (params.pageSize) {
+			searchParams.append('pageSize', params.pageSize.toString());
+		}
+
+		const res: { data: HistoricalTVL[] } = await this.axios.get(`/tvl/historical?${searchParams.toString()}`);
+		return res.data;
+	}
+}

--- a/src/app/ports/backend/IPoolsBackend.ts
+++ b/src/app/ports/backend/IPoolsBackend.ts
@@ -1,0 +1,11 @@
+import { HistoricalTVL, HistoricalTVLParams } from '../../../types/pools';
+
+export interface IPoolsBackend {
+	/**
+	 * Retrieves historical TVL (Total Value Locked) data for a specific vault address and optional pool IDs.
+	 * 
+	 * @param params - Object containing parameters for the historical TVL query
+	 * @returns A promise that resolves to an array of historical TVL data objects.
+	 */
+	historicalTVL(params: HistoricalTVLParams): Promise<HistoricalTVL[]>;
+}

--- a/src/app/services/Pools.ts
+++ b/src/app/services/Pools.ts
@@ -1,12 +1,15 @@
 import { SmartContractAdapter } from '../../adapters/smartContract';
+import { PoolsBackend } from '../../adapters/backend/PoolsBackend';
 import { IContractFactory } from '../ports/IContractFactory';
-import { PoolsTvl } from '../../types/pools';
+import { PoolsTvl, HistoricalTVL, HistoricalTVLParams } from '../../types/pools';
 
 export class Pools {
 	private smartContractAdapter: SmartContractAdapter;
+	private poolsBackend: PoolsBackend;
 
-	constructor(contractFactory: IContractFactory) {
+	constructor(contractFactory: IContractFactory, backendUrl: string, chainId: number) {
 		this.smartContractAdapter = new SmartContractAdapter(contractFactory);
+		this.poolsBackend = new PoolsBackend(backendUrl, chainId);
 	}
 
 	/**
@@ -23,5 +26,22 @@ export class Pools {
 			id: pools[index],
 			tvl: totalAssets.mul(poolSupply).div(totalSupply),
 		}));
+	}
+
+	/**
+	 * Fetch historical Total Value Locked (TVL) data for a specific vault and pool.
+	 *
+	 * @param {HistoricalTVLParams} params - Parameters for querying historical TVL:
+	 *   - `vaultAddress` **(required)**: Vault address to retrieve TVL for.
+	 *   - `poolId` **(required)**: Pool ID to filter data by.
+	 *   - `fromTimestamp` *(optional)*: Start timestamp (in seconds).
+	 *   - `toTimestamp` *(optional)*: End timestamp (in seconds).
+	 *   - `page` *(optional)*: Page number for pagination (starts at 1).
+	 *   - `pageSize` *(optional)*: Number of records per page (max 100).
+	 *
+	 * @returns {Promise<HistoricalTVL[]>} Resolves with an array of historical TVL entries.
+	 */
+	public async historicalTVL(params: HistoricalTVLParams): Promise<HistoricalTVL[]> {
+		return await this.poolsBackend.historicalTVL(params);
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ export class YelayLiteSdk {
 
 		this.yields = new Yield(config.backendUrl, chainId);
 
-		this.pools = new Pools(contractFactory);
+		this.pools = new Pools(contractFactory, config.backendUrl, chainId);
 
 		this.swapperAddress = config.contracts.Swapper;
 	}

--- a/src/types/backend.ts
+++ b/src/types/backend.ts
@@ -1,15 +1,23 @@
-export type TimeFrame = {
-	fromBlock?: number;
-	toBlock?: number;
+export type TimestampFrame = {
 	fromTimestamp?: number;
 	toTimestamp?: number;
 };
+
+export type TimeFrame = {
+	fromBlock?: number;
+	toBlock?: number;
+} & TimestampFrame;
 
 export type EventsRange = {
 	startBlock: number;
 	finishBlock: number;
 	startTimestamp: number;
 	finishTimestamp: number;
+};
+
+export type PaginationParams = {
+	page?: string;
+	pageSize?: string;
 };
 
 export enum SortOrder {

--- a/src/types/pools.ts
+++ b/src/types/pools.ts
@@ -4,3 +4,19 @@ export type PoolsTvl = {
 	id: number;
 	tvl: BigNumber;
 };
+
+export type HistoricalTVL = {
+	vaultAddress: string;
+	poolId: number;
+	createTimestamp: number;
+	assets: BigNumber;
+};
+
+export type HistoricalTVLParams = {
+	vaultAddress: string;
+	poolId: number;
+	fromTimestamp?: number;
+	toTimestamp?: number;
+	page?: number;
+	pageSize?: number;
+};


### PR DESCRIPTION
this PR adds a new `historicalTVL()` method to the Pools service that allows clients to query historical Total Value Locked (TVL) data for specific vaults and pools. The feature uses a clean object parameter pattern for better usability and maintainability. Bumped package version to 1.0.9

Usage Example
```ts
// Fetch historical TVL data with filter options
const historicalTVL = await sdk.pools.historicalTVL({
  vaultAddress: "0x1234...5678", // Required
  poolId: 1,                     // Required
  fromTimestamp: 1641034800,     // Optional
  toTimestamp: 1672570800,       // Optional
  page: 1,                       // Optional
  pageSize: 30                   // Optional
});
```